### PR TITLE
Icon names not cut off

### DIFF
--- a/customStyles/aosAlpha/aosCustomStyle.css
+++ b/customStyles/aosAlpha/aosCustomStyle.css
@@ -369,6 +369,7 @@ div{
                 font-size:12px;
                 text-align:center;
                 width:100px;
+                overflow:inherit;
             }
     #winmove{
         left:0;


### PR DESCRIPTION
On Firefox the names would only partially display if they were longer than one line, like JavaScript Console or Developer Documentation. This removes that issue, at least until a more elegant solution can be implemented.

I know the tooltips say that this project only supports Chrome, but I figured I'd go ahead and resolve this point to try to move away from users being restricted to one browser.

For comparison, Firefox before:
![image](https://user-images.githubusercontent.com/17814535/79695950-593de300-823f-11ea-8e8f-ca449d19e7c5.png)

Firefox now:
![image](https://user-images.githubusercontent.com/17814535/79696306-8db29e80-8241-11ea-84da-e2fe9330dc87.png)

I saw an OS sharing my name and I couldn't not find something to contribute. Great work with this project, man! I read your interview in freeCodeCamp and it was some good stuff. We've had to solve a lot of the same problems, like using URL parameters to bypass cache.

I'm pretty busy with some closed course projects of mine right now, but if you're open to receiving help I'd love to contribute more in the future once I'm freed up a bit more. Us Aaron's have to stick together.